### PR TITLE
:hammer_and_wrench: refactored anime card components

### DIFF
--- a/components/anime/Card.js
+++ b/components/anime/Card.js
@@ -18,7 +18,7 @@ function Card({ anime }) {
     title = `${title.substr(0, 35)}...`
 
   return (
-    <div className='w-46 sm:w-56 p-2 hover:scale-105 transform transition duration-300 ease-out'>
+    <div className='cursor-pointer w-46 sm:w-56 p-2 hover:scale-105 transform transition duration-300 ease-out' onClick={changeRoute}>
       <div className='relative w-40 sm:w-52 h-48 sm:h-64'>
         <Image
           alt="Cover Image"
@@ -31,7 +31,7 @@ function Card({ anime }) {
         />
       </div>
 
-      <div className='cursor-pointer' onClick={changeRoute}>
+      <div>
         <p className='h-12 text-sm mt-2 text-white font-bold'>{title}</p>
 
         <div className='flex space-x-2 text-white text-xs'>

--- a/components/watch/Card.js
+++ b/components/watch/Card.js
@@ -17,7 +17,7 @@ function Card({ anime }) {
       className='flex space-x-4 ml-2 text-white py-2 h-30 cursor-pointer hover:scale-105 transform transition duration-300 ease-out'
       onClick={changeRoute}
     >
-      <div className='relative w-40 h-28'>
+      <div className='relative w-24 h-32'>
         <Image
           alt={anime.title.english || anime.title.romaji}
           src={anime.coverImage.large || anime.coverImage.medium || anime.bannerImage}


### PR DESCRIPTION
## This pr refactors two behaviors of the anime cards

### 1. Clicking
Before, the image of the anime card was not clickable on the home screen and the Anime screen. If you wanted to navigate to an Anime, you would have to click on the title.
<details>
<summary>Example</summary>

| Before | After |
|-|-|
| ![chrome_5254aAnegX](https://user-images.githubusercontent.com/60541979/165157279-2eb475de-a7a4-439f-9a01-ab898f994c9b.gif) |  ![chrome_kaLCF5fQmL](https://user-images.githubusercontent.com/60541979/165156197-6206b0ce-d6b7-4fa2-8119-eafc00ddb5f6.gif)  |
</details>

---
### 2. aspect ratio
I noticed that the images for recommended Anime on the watch page had a weird aspect ratio so I tweaked the width of the anime cards.
<details>
<summary>Example</summary>

| Before | After |
|-|-|
| ![image](https://user-images.githubusercontent.com/60541979/165157107-e4e2fe33-43e5-4ac0-a47b-716299603277.png) | ![image](https://user-images.githubusercontent.com/60541979/165156851-208d8ef7-c4e4-4de9-b794-324cb0e8ec5a.png) |
</details>
