### PR TITLE
show 7 items instead of 8

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -33,19 +33,19 @@ export async function getServerSideProps() {
       ...animeBannerFragment
     }
 
-    trending: Page(perPage: 8) {
+    trending: Page(perPage: 7) {
       media(sort: TRENDING_DESC, type: ANIME) {
         ...animeInfoFragment
       }
     }
 
-    popular: Page(perPage: 8) {
+    popular: Page(perPage: 7) {
       media(sort: POPULARITY_DESC, type: ANIME) {
         ...animeInfoFragment
       }
     }
 
-    topRated: Page(perPage: 8) {
+    topRated: Page(perPage: 7) {
       media(sort: SCORE_DESC, type: ANIME) {
         ...animeInfoFragment
       }


### PR DESCRIPTION
As you can see in this picture the last anime shows just half

![image](https://user-images.githubusercontent.com/11579313/166504892-499e7c39-97a9-4d26-bcc8-817f76c58d43.png)

After using 7 it looks normal

![image](https://user-images.githubusercontent.com/11579313/166504957-ce3283f9-f1fd-4467-b929-afcbfa254b4d.png)
