### PR TITLE
fix: added null safety to video player; added gogo episode list length

### DIFF
--- a/src/components/Episode.js
+++ b/src/components/Episode.js
@@ -69,7 +69,9 @@ function Episode({ id, episodes }) {
           .map((v) => (
             <Link key={v} passHref href={`/watch/${id}/?episode=${v}`}>
               <a className="text-gray-800">
-                <div className="bg-gray-100 py-[1px] px-1 rounded-sm">{v}</div>
+                <div className="bg-gray-100 py-[1px] px-1 rounded-sm hover:bg-gray-400">
+                  {v}
+                </div>
               </a>
             </Link>
           ))}

--- a/src/components/VideoPlayer.js
+++ b/src/components/VideoPlayer.js
@@ -30,7 +30,7 @@ export default function VideoPlayer({
     // Enable fullscreen keyboard shortcuts in fullscreen
     document.addEventListener('keydown', (e) => {
       if (
-        videoplayer.current.isFullscreenActive &&
+        videoplayer.current?.isFullscreenActive &&
         e.target !== videoplayer.current
       ) {
         // Create a new keyboard event

--- a/src/pages/watch/[id].js
+++ b/src/pages/watch/[id].js
@@ -169,8 +169,11 @@ export async function getServerSideProps(context) {
 
   let videoLink = null;
   let referer = null;
+  let episodes = null;
   if (res.videoLink !== undefined) {
-    ({ videoLink, referer } = res);
+    ({ videoLink, referer, episodes } = res);
+
+    if (episodes.length !== 0) data.anime.episodes = episodes.length;
   }
 
   return {

--- a/src/utility/gogoanime.js
+++ b/src/utility/gogoanime.js
@@ -1,4 +1,8 @@
-import { scrapeMP4, scrapeSearch } from 'gogoanime-api/lib/anime_parser';
+import {
+  scrapeMP4,
+  scrapeSearch,
+  scrapeAnimeDetails,
+} from 'gogoanime-api/lib/anime_parser';
 
 async function getAnime(slug, episode) {
   if (!slug || slug === '') return {};
@@ -9,8 +13,13 @@ async function getAnime(slug, episode) {
 
   if (findAnime.length === 0) return {};
 
+  const gogoEpisodes = (await scrapeAnimeDetails({ id: findAnime[0].animeId }))
+    .episodesList;
+
+  const episodeSlugId = gogoEpisodes[0]?.episodeId.split('-episode')[0];
+
   const data = await scrapeMP4({
-    id: `${findAnime[0].animeId}-episode-${episode}`,
+    id: `${episodeSlugId}-episode-${episode}`,
   });
 
   const bestQuality = data.sources?.[data.sources.length - 1].file;
@@ -18,6 +27,7 @@ async function getAnime(slug, episode) {
   return {
     referer: data.Referer,
     videoLink: bestQuality,
+    episodes: gogoEpisodes,
   };
 }
 


### PR DESCRIPTION
 - sometimes the video was crashing on `isFullscreenActive` due to being undefined so i added null safety.
 - Since anilist isn't very reliable, I've begun using gogoanime episode length instead. Also, the episode slug has been modified, which should resolve the issue with many animes not loading ("tate no yuusha season 2" for example).
 - feat: enable hover color for episodes