### PR TITLE
fix: getKitsuEpisodes type missmatch

### DIFF
--- a/src/utility/gogoanime.js
+++ b/src/utility/gogoanime.js
@@ -140,12 +140,15 @@ export async function getKitsuEpisodes(slug, startDate, season) {
     gogoEpisodes.reverse();
     gogoEpisodes.forEach((gogoEp, i) => {
       const j = (i + 1).toString();
+      const ep = episodesList.get(j);
       newEpisodeList.push({
         episodeId: gogoEp.episodeId,
-        episodeTitle: episodesList.get(j).title,
-        episodeThumbnail: episodesList.get(j).thumbnail,
+        episodeTitle: ep
+          ? episodesList.get(j).title
+          : `Episode: ${gogoEp.episodeNum}`,
+        episodeThumbnail: ep ? episodesList.get(j).thumbnail : null,
         episodeNum: gogoEp.episodeNum,
-        episodeDescription: episodesList.get(j).description,
+        episodeDescription: ep ? episodesList.get(j).description : null,
       });
     });
   }

--- a/src/utility/gogoanime.js
+++ b/src/utility/gogoanime.js
@@ -98,7 +98,7 @@ export async function getKitsuEpisodes(slug, startDate, season) {
       nodes.forEach((node) => {
         if (
           node.season === season &&
-          node.startDate.trim().split('-')[0] === startDate
+          node.startDate.trim().split('-')[0] === startDate.toString()
         ) {
           const episodes = node.episodes.nodes;
 


### PR DESCRIPTION
This pr fixes a type missmatch in the `getKitsuEpisodes()` function

startDate is of type int
node.startDate is of type string

the strict equality operator from javascript (===) will therefore always return false