### PR TITLE
feat: added episode progress tracking and Continue watching section

### DIFF
--- a/src/components/VideoPlayer.js
+++ b/src/components/VideoPlayer.js
@@ -10,6 +10,8 @@ export default function VideoPlayer({
   poster,
   previousCallback,
   nextCallback,
+  saveProgressCallback,
+  startTime,
 }) {
   const videoplayer = useRef(null);
 
@@ -48,8 +50,23 @@ export default function VideoPlayer({
     });
   });
 
+  // save episode progress every 2 minutes
+  useEffect(() => {
+    const intervalID = setInterval(() => {
+      saveProgressCallback(videoplayer.current.currentTime);
+    }, 1000 * 60 * 2);
+    return () => clearInterval(intervalID);
+  }, [saveProgressCallback]);
+
   return (
-    <Player ref={videoplayer} tabIndex="0" style={{ outline: 'none' }}>
+    <Player
+      ref={videoplayer}
+      tabIndex="0"
+      style={{ outline: 'none' }}
+      onVmPlaybackReady={() => {
+        videoplayer.current.currentTime = startTime;
+      }}
+    >
       {src.includes('m3u8') ? (
         <Hls version="latest" poster={poster} key={src}>
           <source data-src={src} type="application/x-mpegURL" />

--- a/src/components/anime/Banner.js
+++ b/src/components/anime/Banner.js
@@ -70,9 +70,7 @@ function Banner({ anime, onLoadingComplete }) {
 
         <Link
           href={
-            router.route === '/'
-              ? `/anime/${anime.id}`
-              : `/watch/${anime.id}?episode=1`
+            router.route === '/' ? `/anime/${anime.id}` : `/watch/${anime.id}`
           }
           passHref
         >

--- a/src/components/watch/Card.js
+++ b/src/components/watch/Card.js
@@ -9,7 +9,7 @@ import { base64SolidImage } from '@utility/image';
 
 function Card({ anime }) {
   return (
-    <Link href={`/watch/${anime.id}?episode=1`} passHref>
+    <Link href={`/watch/${anime.id}`} passHref>
       <a className="flex space-x-4 ml-2 mr-4 text-white py-2 h-30 cursor-pointer hover:scale-105 transform transition duration-300 ease-out">
         <div className="relative min-w-[6rem] min-h-[8rem] flex-shrink-1">
           <Image

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 import Section from '@components/anime/Section';
 import { progress } from '@pages/_app';
@@ -13,6 +13,29 @@ export default function Home({ banner, trending, popular, topRated }) {
     progress.finish();
   });
 
+  const [recentlyWatched, setRecentlyWatched] = useState([]);
+
+  // populate recentlyWatched
+  useEffect(() => {
+    const anime = Object.keys(localStorage)
+      .filter((key) => key.startsWith('Anime'))
+      .map((key) => parseInt(key.replace('Anime', ''), 10));
+
+    const query = `
+      {
+        media: Page(perPage: 12) {
+          media(id_in: [${anime.join(', ')}]) {
+          ...animeInfoFragment
+          }
+        }
+      }
+      ${animeInfoFragment}
+    `;
+    client.request(query).then((data) => {
+      setRecentlyWatched(data.media.media);
+    });
+  }, []);
+
   return (
     <>
       <Header />
@@ -20,6 +43,10 @@ export default function Home({ banner, trending, popular, topRated }) {
       <Banner anime={banner} onLoadingComplete={progress.finish} />
 
       <Section title="Trending Now" animeList={trending} />
+      {/* only show */}
+      {recentlyWatched.length > 0 ? (
+        <Section title="Continue watching" animeList={recentlyWatched} />
+      ) : null}
       <Section title="Popular" animeList={popular} />
       <Section title="Top Rated (All time)" animeList={topRated} />
     </>

--- a/src/pages/watch/[id].js
+++ b/src/pages/watch/[id].js
@@ -23,8 +23,20 @@ function Video({ anime, recommended }) {
 
   const { id, episode } = router.query;
 
-  if (typeof window !== 'undefined' && !episode) {
-    router?.push(`/watch/${id}?episode=${1}`);
+  let startTime = 0;
+
+  if (typeof window !== 'undefined') {
+    const savedState = localStorage.getItem(`Anime${id}`) || '1-0';
+    const [savedEpisode, savedTime] = savedState.split('-');
+
+    if (!episode) {
+      router?.push(`/watch/${id}?episode=${savedEpisode || 1}`);
+    }
+    // check if last watched episode in localstorage
+
+    if (episode === savedEpisode) {
+      startTime = parseInt(savedTime, 10);
+    }
   }
 
   const { videoLink, referer, episodes, isError } = useAnime(id, episode);
@@ -35,6 +47,10 @@ function Video({ anime, recommended }) {
 
   const nextEpisode = () => {
     router.push(`/watch/${id}?episode=${parseInt(episode, 10) + 1}`);
+  };
+
+  const saveProgress = (time) => {
+    localStorage.setItem(`Anime${id}`, `${episode}-${time}`);
   };
 
   const urls = useMemo(() => {
@@ -63,6 +79,8 @@ function Video({ anime, recommended }) {
               poster={anime.bannerImage}
               nextCallback={nextEpisode}
               previousCallback={previousEpisode}
+              saveProgressCallback={saveProgress}
+              startTime={startTime}
             />
           ) : (
             <p className="font-semibold text-white mt-4 ml-3 sm:ml-6 text-base sm:text-lg md:text-xl lg:text-2xl xl:text-3xl 2xl:text-4xl">


### PR DESCRIPTION
This pr implements episode progress tracking and a recently watched section

## Progress tracking
When you start watching an anime, the player will start syncing the time every 2 minutes to the localstorage
in the following format: `Anime<id>`: `<episode>-<time in seconds>`

## Behavior
When you click on an anime tile, clicking the 'Watch now' button will continue from the last saved point or from episode 1 if the Anime was not watched yet.

Clicking a specific episodes works as expected and plays the specified episode

---

## Continue watching

The index page now features a section containing the recently watched anime
![image](https://user-images.githubusercontent.com/60541979/168424089-f2511aea-30bb-4875-8536-5ab4ef6ec7b2.png)
