### PR TITLE
feat: remove anime progress at the end of the last episode

### DIFF
--- a/src/pages/watch/[id].js
+++ b/src/pages/watch/[id].js
@@ -50,6 +50,11 @@ function Video({ anime, recommended }) {
   };
 
   const saveProgress = (time) => {
+    // delete progress if on last episode
+    if (episode === episodes.toString() && time > 60 * 10) {
+      localStorage.removeItem(`Anime${id}`);
+      return;
+    }
     localStorage.setItem(`Anime${id}`, `${episode}-${time}`);
   };
 


### PR DESCRIPTION
This pr implements the removal of an Anime from the progress tracking, once you are watching the last ~10 minutes of the anime.