### PR TITLE
Fixed HTML tags rendering in anime description banners

### DIFF
--- a/src/components/anime/Banner.tsx
+++ b/src/components/anime/Banner.tsx
@@ -66,8 +66,9 @@ const Banner: React.FC<BannerProps> = ({ anime }) => {
           ))}
         </div>
 
+      
         <p className="hidden max-w-3xl md:block md:line-clamp-3 lg:line-clamp-4 xl:line-clamp-5 2xl:line-clamp-6">
-          {description}
+          {description.replace(/<[^>]*>?/gm, '')}
         </p>
 
         {/* the button at the bottom */}

--- a/src/components/anime/Banner.tsx
+++ b/src/components/anime/Banner.tsx
@@ -66,7 +66,6 @@ const Banner: React.FC<BannerProps> = ({ anime }) => {
           ))}
         </div>
 
-      
         <p className="hidden max-w-3xl md:block md:line-clamp-3 lg:line-clamp-4 xl:line-clamp-5 2xl:line-clamp-6">
           {description.replace(/<[^>]*>?/gm, '')}
         </p>

--- a/src/components/anime/Banner.tsx
+++ b/src/components/anime/Banner.tsx
@@ -11,6 +11,7 @@ import Genre from '@components/Genre';
 import Icon from '@components/Icon';
 import progressBar from '@components/Progress';
 import { AnimeBannerFragment } from '@generated/aniList';
+import { stripHtml } from '@utility/utils';
 
 export interface BannerProps {
   anime: AnimeBannerFragment;
@@ -23,9 +24,6 @@ const Banner: React.FC<BannerProps> = ({ anime }) => {
   useEffect(() => {
     if (!anime.bannerImage) progressBar.finish();
   }, [anime.bannerImage]);
-
-  // remove all the html tags
-  const description = anime.description.replace(/<\w*\\?>/g, '');
 
   return (
     <div className="relative h-[200px] sm:h-[250px] md:h-[300px] lg:h-[350px] xl:h-[400px] 2xl:h-[450px]">
@@ -67,7 +65,7 @@ const Banner: React.FC<BannerProps> = ({ anime }) => {
         </div>
 
         <p className="hidden max-w-3xl md:block md:line-clamp-3 lg:line-clamp-4 xl:line-clamp-5 2xl:line-clamp-6">
-          {description.replace(/<[^>]*>?/gm, '')}
+          {stripHtml(anime.description)}
         </p>
 
         {/* the button at the bottom */}

--- a/src/utility/utils.ts
+++ b/src/utility/utils.ts
@@ -6,3 +6,5 @@ export const proxyUrl = (url: string, referer: string) => {
 
 export const arrayToString = (data: string | string[]) =>
   typeof data === 'string' ? data : data.join('');
+
+export const stripHtml = (data: string) => data.replace(/<\/?\w*\\?>/gm, '');


### PR DESCRIPTION
# Problem - HTML tags rendering in the description of anime banner

![image](https://user-images.githubusercontent.com/45560312/173208664-62f20029-9d6c-4df4-b283-eea6b91eb35c.png)


# Solution

In `Banner.tsx` i have used a `regex` function `/<[^>]*>?/gm` to replace `nth` amount of html tags in banner description.
you may refer to the changes below in source code.

# Patch Result

![image](https://user-images.githubusercontent.com/45560312/173208570-99e7a5e9-7cc8-4f48-8315-6bc4e4adc3ac.png)

## Additional notes 

just click the photo to render higher quality which i have attached