### PR TITLE
Docker Image Support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,10 +59,9 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.ACCESS_TOKEN }}
 
       - name: Publish Docker Image
-        if: ${{ github.event_name == 'push' }}
         run: | 
           docker build -t ghcr.io/${{ github.actor }}/animeflix .
           docker push ghcr.io/${{ github.actor }}/animeflix:latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,12 +7,15 @@ on:
   pull_request:
     branches:
       - main
+
 jobs:
-  ci:
+  # lint and test the project
+  lint-test:
     runs-on: ubuntu-latest
     # env:
     #   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
     #   TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3
@@ -41,9 +44,15 @@ jobs:
       - name: Run tests
         run: yarn test
   
-  DockerPublish:
-    needs: [ci]
+  # publish to github container registry
+  publish-docker:
+    # only run if lint and test is success
+    needs: [lint-test]
+    # only run if the workflow was triggered on push
+    if: github.event_name == 'push'
+    
     runs-on: ubuntu-latest
+
     steps:
       - name: login to GitHub Container Registry
         uses: docker/login-action@v1
@@ -51,6 +60,7 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Publish Docker Image
         if: ${{ github.event_name == 'push' }}
         run: | 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,15 +7,12 @@ on:
   pull_request:
     branches:
       - main
-
 jobs:
   ci:
     runs-on: ubuntu-latest
-
     # env:
     #   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
     #   TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
-
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3
@@ -43,4 +40,19 @@ jobs:
 
       - name: Run tests
         run: yarn test
-
+  
+  DockerPublish:
+    needs: [ci]
+    runs-on: ubuntu-latest
+    steps:
+      - name: login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Publish Docker Image
+        if: ${{ github.event_name == 'push' }}
+        run: | 
+          docker build -t ghcr.io/${{ github.actor }}/animeflix .
+          docker push ghcr.io/${{ github.actor }}/animeflix:latest


### PR DESCRIPTION
As per previous discussions. I have closed down the old repo as the commits were too high when testing. @chirag-droid 

The docker image is built when CI is passed and only runs if it is a push.

using 

` if: ${{ github.event_name == 'push' }}`